### PR TITLE
new format spoiler + added new chars to FMT_CHARS

### DIFF
--- a/docs/sheets/formatting.md
+++ b/docs/sheets/formatting.md
@@ -17,6 +17,7 @@ Formatter is derived from `str` and always implements these methods:
 * `.italic()`
 * `.underline()`
 * `.strike()`
+* `.spoiler()`
 * `.link(href: str)`
 * `.mention(user_id: int)`
 * `.code_block()`

--- a/telegrinder/tools/formatting/abc.py
+++ b/telegrinder/tools/formatting/abc.py
@@ -32,6 +32,10 @@ class ABCFormatter(ABC, str):
     def link(self: T, href: str) -> T:
         ...
 
+    @abstractmethod
+    def spoiler(self: T) -> T:
+        ...
+
     def mention(self: T, user_id: int) -> T:
         return self.link(get_mention_link(user_id))
 

--- a/telegrinder/tools/formatting/html.py
+++ b/telegrinder/tools/formatting/html.py
@@ -33,6 +33,9 @@ class HTMLFormatter(ABCFormatter):
 
     def strike(self) -> "HTMLFormatter":
         return wrap_tag("s", self)
+    
+    def spoiler(self) -> "HTMLFormatter":
+        return wrap_tag("tg-spoiler", self)
 
     def link(self, href: str) -> "HTMLFormatter":
         return wrap_tag(

--- a/telegrinder/tools/formatting/markdown.py
+++ b/telegrinder/tools/formatting/markdown.py
@@ -1,8 +1,7 @@
 from .abc import ABCFormatter
-import typing
 from telegrinder.tools.parse_mode import ParseMode
 
-FMT_CHARS = "\\`*_{}[]()#+-!"
+FMT_CHARS = "\\`*_{}[]()#+-=!.@~|"
 
 
 def wrap_md(wrapper: str, s: str) -> "MarkdownFormatter":
@@ -13,13 +12,10 @@ class MarkdownFormatter(ABCFormatter):
     PARSE_MODE = ParseMode.MARKDOWNV2
 
     def escape(self) -> "MarkdownFormatter":
-        ns = ""
-        for c in self:
-            if c in FMT_CHARS:
-                ns += "\\"
-            ns += c
-        ns = ns.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-        return MarkdownFormatter(ns)
+        return MarkdownFormatter(
+            "".join("\\" + x if x in FMT_CHARS else x for x in self)
+            .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        )
 
     def escape_code(self) -> "MarkdownFormatter":
         return self.replace("\\", "\\\\").replace("`", "\\`")
@@ -38,12 +34,15 @@ class MarkdownFormatter(ABCFormatter):
 
     def strike(self) -> "MarkdownFormatter":
         return wrap_md("~", self)
+    
+    def spoiler(self) -> "MarkdownFormatter":
+        return wrap_md("||", self)
 
     def link(self, href: str) -> "MarkdownFormatter":
         return MarkdownFormatter(
             f"[{self.escape()}]({MarkdownFormatter(href).escape_link()})"
         )
-
+    
     def code_block(self) -> "MarkdownFormatter":
         return MarkdownFormatter(f"```\n{self.escape_code()}\n```")
 


### PR DESCRIPTION
New characters added: **=.@~|** for escaping when formatting text. The _telegram API_ was previously sending an error that the above characters require escaping. A new format "**spoiler**" has also been added for **MarkdownFormatter** and **HTMLFormatter**. Redesigned in **MarkdownFormatter** method "**escape**".