### PR TITLE
Add the `is_waiting_for` method for WaiterMachine

### DIFF
--- a/examples/easy.py
+++ b/examples/easy.py
@@ -15,6 +15,7 @@ kitten_bytes = pathlib.Path("examples/assets/kitten.jpg").read_bytes()
 logger.set_level("INFO")
 
 
+
 @bot.on.message(Text("/start"))
 async def start(message: Message):
     me = (await api.get_me()).unwrap().first_name
@@ -25,6 +26,7 @@ async def start(message: Message):
         bot.dispatch.message,
         message,
         Text(["fine", "bad"], ignore_case=True),
+        exit=MessageReplyHandler("Oh, ok, exiting state...", Text("/exit")),
         default=MessageReplyHandler("Fine or bad"),
     )
 

--- a/telegrinder/bot/dispatch/waiter_machine/machine.py
+++ b/telegrinder/bot/dispatch/waiter_machine/machine.py
@@ -75,15 +75,12 @@ class WaiterMachine:
 
         api: ABCAPI
         key: Identificator
-<<<<<<< HEAD
         api, key = (
             linked
             if isinstance(linked, tuple)
             else (linked.ctx_api, state_view.get_state_key(linked))
         )  # type: ignore
-=======
         api, key = linked if isinstance(linked, tuple) else (linked.ctx_api, state_view.get_state_key(linked))  # type: ignore
->>>>>>> 9ae36b1 (exit_behaviour for waiter machine)
         if not key:
             raise RuntimeError("Unable to get state key.")
 

--- a/telegrinder/bot/dispatch/waiter_machine/machine.py
+++ b/telegrinder/bot/dispatch/waiter_machine/machine.py
@@ -116,11 +116,11 @@ class WaiterMachine:
         update: Update,
         behaviour: Behaviour[EventModel] | None = None,
         **context: typing.Any,
-    ) -> None:
+    ) -> bool:
         # TODO: support view as a behaviour
 
         if behaviour is None:
-            return
+            return False
 
         ctx = Context(**context)
         if isinstance(event, asyncio.Event):
@@ -132,6 +132,6 @@ class WaiterMachine:
 
         if await behaviour.check(event.api, update, ctx):
             await behaviour.run(event, ctx)
-        
+            return True
 
 __all__ = ("WaiterMachine",)

--- a/telegrinder/bot/dispatch/waiter_machine/machine.py
+++ b/telegrinder/bot/dispatch/waiter_machine/machine.py
@@ -67,6 +67,7 @@ class WaiterMachine:
         *rules: ABCRule[EventModel],
         default: Behaviour[EventModel] | None = None,
         on_drop: Behaviour[EventModel] | None = None,
+        exit: Behaviour[EventModel] | None = None,
         expiration: datetime.timedelta | float | None = None,
     ) -> ShortStateContext[EventModel]:
         if isinstance(expiration, int | float):
@@ -74,11 +75,15 @@ class WaiterMachine:
 
         api: ABCAPI
         key: Identificator
+<<<<<<< HEAD
         api, key = (
             linked
             if isinstance(linked, tuple)
             else (linked.ctx_api, state_view.get_state_key(linked))
         )  # type: ignore
+=======
+        api, key = linked if isinstance(linked, tuple) else (linked.ctx_api, state_view.get_state_key(linked))  # type: ignore
+>>>>>>> 9ae36b1 (exit_behaviour for waiter machine)
         if not key:
             raise RuntimeError("Unable to get state key.")
 
@@ -92,6 +97,7 @@ class WaiterMachine:
             expiration=expiration,
             default_behaviour=default,
             on_drop_behaviour=on_drop,
+            exit_behaviour=exit,
         )
         
         if view_name not in self.storage:

--- a/telegrinder/bot/dispatch/waiter_machine/middleware.py
+++ b/telegrinder/bot/dispatch/waiter_machine/middleware.py
@@ -53,15 +53,15 @@ class WaiterMiddleware(ABCMiddleware[EventType]):
 
         # before running the handler we check if the user wants to exit waiting
         if short_state.exit_behaviour is not None:
-            await self.machine.call_behaviour(
+            if await self.machine.call_behaviour(
                 self.view,
                 event,
                 ctx.raw_update,
                 behaviour=short_state.exit_behaviour,
                 **preset_context,
-            )
-            await self.machine.drop(self.view, short_state.key, ctx.raw_update, **preset_context.copy())
-            return True
+            ):
+                await self.machine.drop(self.view, short_state.key, ctx.raw_update, **preset_context.copy())
+                return True
 
         handler = FuncHandler(
             self.pass_runtime,

--- a/telegrinder/bot/dispatch/waiter_machine/middleware.py
+++ b/telegrinder/bot/dispatch/waiter_machine/middleware.py
@@ -51,6 +51,18 @@ class WaiterMiddleware(ABCMiddleware[EventType]):
             await self.machine.drop(self.view, short_state.key, ctx.raw_update, **preset_context.copy())
             return True
 
+        # before running the handler we check if the user wants to exit waiting
+        if short_state.exit_behaviour is not None:
+            await self.machine.call_behaviour(
+                self.view,
+                event,
+                ctx.raw_update,
+                behaviour=short_state.exit_behaviour,
+                **preset_context,
+            )
+            await self.machine.drop(self.view, short_state.key, ctx.raw_update, **preset_context.copy())
+            return True
+
         handler = FuncHandler(
             self.pass_runtime,
             list(short_state.rules),

--- a/telegrinder/bot/dispatch/waiter_machine/short_state.py
+++ b/telegrinder/bot/dispatch/waiter_machine/short_state.py
@@ -36,6 +36,7 @@ class ShortState(typing.Generic[EventModel]):
     )
     default_behaviour: Behaviour[EventModel] | None = dataclasses.field(default=None)
     on_drop_behaviour: Behaviour[EventModel] | None = dataclasses.field(default=None)
+    exit_behaviour: Behaviour[EventModel] | None = dataclasses.field(default=None)
     expiration_date: datetime.datetime | None = dataclasses.field(init=False)
     context: ShortStateContext[EventModel] | None = dataclasses.field(default=None, init=False)
 


### PR DESCRIPTION
### ✏️ Description ✏️
There was no way to look if the waiter machine is waiting for a message from a user. This is needed when cancelling a waiting or other fancy stuff.

The PR is too big cause of `black` formatting. 

```python

wm.is_waiting_for(bot.on.message, message.from_user.id)

```

`🐛 Fixes # (issue)`

### 📍 Type of change 📍

<!-- Please delete options that are not relevant.-->

- [x] 🚀 New feature (non-breaking change which adds functionality) 🚀
- [x] 📝 This change requires a documentation update 📝
