### PR TITLE
Remove unnecessary positional-only marker in constructor

### DIFF
--- a/telegrinder/types/input_file.py
+++ b/telegrinder/types/input_file.py
@@ -21,7 +21,7 @@ class InputFile:
     data: bytes
     """Bytes of file."""
 
-    def __init__(self, filename: str, data: bytes, /) -> None:
+    def __init__(self, filename: str, data: bytes) -> None:
         self.filename = filename
         self.data = data
 


### PR DESCRIPTION
### ✏️ Description ✏️
The positional-only marker in the constructor was redundant and has been removed for clarity. This change improves code readability and aligns with common Python conventions.

### 📍 Type of change 📍
- [x] 🐛 Bug fix (non-breaking change which fixes an issue) 🐛
