### PR TITLE
Fix node dependency resolution and support cleanup for PER_CALL nodes

### DIFF
--- a/telegrinder/bot/dispatch/dispatch.py
+++ b/telegrinder/bot/dispatch/dispatch.py
@@ -138,7 +138,7 @@ class Dispatch(
                         raise exception
                 finally:
                     for session in context.get(CONTEXT_STORE_NODES_KEY, {}).values():
-                        await session.close(scopes=(NodeScope.PER_EVENT,))
+                        await session.close(scopes=(NodeScope.PER_EVENT, NodeScope.PER_CALL))
 
         await run_middleware(
             self.global_middleware.post,

--- a/telegrinder/bot/rules/payload.py
+++ b/telegrinder/bot/rules/payload.py
@@ -51,12 +51,10 @@ class PayloadModelRule[Model: ModelType](PayloadRule):
         self.payload = payload
 
     def check(self, payload: PayloadData[Model], context: Context) -> bool:
-        if self.payload is not _ANY:
-            if payload != self.payload:
-                return False
+        if self.payload is not _ANY and payload != self.payload:
+            return False
 
-            context.set(self.alias, payload)
-
+        context.set(self.alias, payload)
         return True
 
 

--- a/telegrinder/bot/rules/payload.py
+++ b/telegrinder/bot/rules/payload.py
@@ -13,7 +13,7 @@ from telegrinder.node.payload import Payload, PayloadData
 from telegrinder.tools.callback_data_serialization.abc import ABCDataSerializer, ModelType
 from telegrinder.tools.callback_data_serialization.json_ser import JSONSerializer
 
-_sentinel = object()
+_ANY: typing.Final = object()
 
 
 class PayloadRule[Data](ABCRule):
@@ -43,7 +43,7 @@ class PayloadModelRule[Model: ModelType](PayloadRule):
         model_t: type[Model],
         /,
         *,
-        payload: typing.Any = _sentinel,
+        payload: typing.Any = _ANY,
         serializer: type[ABCDataSerializer[Model]] | None = None,
         alias: str | None = None,
     ) -> None:
@@ -51,9 +51,12 @@ class PayloadModelRule[Model: ModelType](PayloadRule):
         self.payload = payload
 
     def check(self, payload: PayloadData[Model], context: Context) -> bool:
-        if self.payload is not _sentinel and payload != self.payload:
-            return False
-        context.set(self.alias, payload)
+        if self.payload is not _ANY:
+            if payload != self.payload:
+                return False
+
+            context.set(self.alias, payload)
+
         return True
 
 

--- a/telegrinder/node/attachment.py
+++ b/telegrinder/node/attachment.py
@@ -5,7 +5,8 @@ from fntypes.option import Nothing, Option, Some
 
 import telegrinder.types
 from telegrinder.bot.cute_types.message import MessageCute
-from telegrinder.node.base import ComposeError, DataNode, scalar_node
+from telegrinder.node.base import DataNode, scalar_node
+from telegrinder.node.exceptions import ComposeError
 
 type AttachmentType = typing.Literal[
     "audio",

--- a/telegrinder/node/tools/generator.py
+++ b/telegrinder/node/tools/generator.py
@@ -1,7 +1,8 @@
 import typing
 
-from telegrinder.node.base import ComposeError, IsNode, Node
+from telegrinder.node.base import IsNode, Node
 from telegrinder.node.container import ContainerNode
+from telegrinder.node.exceptions import ComposeError
 from telegrinder.tools.aio import maybe_awaitable
 
 


### PR DESCRIPTION

### ✏️ Description ✏️

This PR fixes incorrect dependency resolution for nodes composition system.  
It introduces proper topological sorting to ensure all dependent nodes — including `PER_CALL` scoped ones — are resolved in the correct order.

Additionally:
- `PER_CALL` nodes are now properly closed after handler execution (alongside `PER_EVENT` nodes)
- Improved detection of circular and self-referencing dependencies via `ComposeError`
- Minor cleanup and type safety improvements in node handling


---

### 📍 Type of change 📍
- [x] 🐛 Bug fix (non-breaking change which fixes an issue) 🐛
- [ ] 🚀 New feature (non-breaking change which adds functionality) 🚀
- [ ] ⚡ Breaking change (fix or feature that would cause existing functionality not to work as expected) ⚡
- [ ] 📝 This change requires a documentation update 📝

---

### ⚪️ Checklist ⚪️
- [ ] 📝 Your code has documentation 📝
- [ ] 🔧 Your code has tests 🔧 *(via existing node resolution behavior + validation through usage)*
- [ ] 🪄 Your code has example usage in `/examples` 🪄 *(can be added separately if needed)*