### PR TITLE
fix: restore enum values with msgspex 1.7

### DIFF
--- a/telegrinder/types/enums.py
+++ b/telegrinder/types/enums.py
@@ -1,4 +1,26 @@
-from msgspex import BaseEnumMeta, IntEnum, StrEnum
+import enum
+import typing
+
+from msgspex import BaseEnumMeta as MsgspexBaseEnumMeta
+from msgspex import IntEnum, StrEnum
+
+
+def _get_enum_value(instance: object) -> typing.Any:
+    return object.__getattribute__(instance, "_value_")
+
+
+class BaseEnumMeta(MsgspexBaseEnumMeta):
+    """Restore the public enum value descriptor omitted by msgspex 1.7.0."""
+
+    def __new__(
+        metacls,
+        cls: str,
+        bases: tuple[type[typing.Any], ...],
+        classdict: enum.EnumDict,
+        **kwargs: typing.Any,
+    ) -> typing.Any:
+        classdict["value"] = property(_get_enum_value)
+        return super().__new__(metacls, cls, bases, classdict, **kwargs)
 
 
 class ProgrammingLanguage(StrEnum, metaclass=BaseEnumMeta):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -22,6 +22,8 @@ from telegrinder.api.error import APIError
 from telegrinder.api.token import Token
 from telegrinder.bot.cute_types.base import compose_method_params
 from telegrinder.bot.cute_types.managed_bot_updated import ManagedBotUpdatedCute
+from telegrinder.bot.cute_types.message import MessageCute
+from telegrinder.bot.cute_types.update import UpdateCute
 from telegrinder.bot.cute_types.utils import exclude_bound_parameters
 from telegrinder.bot.dispatch.context import Context
 from telegrinder.bot.dispatch.middleware.box import MiddlewareBox
@@ -115,6 +117,28 @@ class _Generic[T, *Ts]:  # PEP 695 generic where the TypeVarTuple is NOT the fir
 
 
 # --------------------------------------------------------------------------- dispatch & middleware
+
+
+def test_update_cute_decoding_uses_enum_value():
+    raw_update = msgspec.json.encode(
+        {
+            "update_id": 1,
+            "message": {
+                "message_id": 1,
+                "date": 1_713_971_200,
+                "chat": {"id": 1, "type": "private", "first_name": "Cute"},
+                "text": "hello",
+            },
+        },
+    )
+
+    api = API(Token("123:ABCdef"), http=MockedHttpClient())
+    update = UpdateCute.from_raw(raw_update, api)
+
+    assert update.update_type.value == "message"
+    assert str(update.update_type) == "message"
+    assert isinstance(update.incoming_update, MessageCute)
+    assert update.incoming_update.message_id == 1
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary

- keep the current `msgspex` 1.7.0 dependency
- restore the public `.value` descriptor on Telegrinder enums through its enum metaclass
- cover the complete `UpdateCute.from_raw()` decoding path with a regression test

## Root cause

`msgspex` 1.7.0 builds a custom enum base by copying methods from `enum.Enum`, but does not copy the public `value` descriptor. Telegrinder relies on that descriptor to resolve and bind incoming updates, so polling repeatedly raised `AttributeError` while decoding them.

The compatibility descriptor is added by Telegrinder's metaclass for every generated string and integer enum. This preserves the new `msgspex` release and its unsupported-member behavior.

## Impact

Bots using `Telegrinder.run_forever()` can decode incoming updates normally with `msgspex` 1.7.0.

Closes #450

## Validation

- `uv run pytest -q` — 103 passed, 1 skipped
- `uv run basedpyright` — 0 errors
- Ruff checks pass for the changed files
- live Telegram polling with `msgspex 1.7.0` decoded a `message` update as `MessageCute`